### PR TITLE
Fix repo README link to be relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AWS RoboMaker Simulation ROS Packages
 
 ROS packages for using with AWS RoboMaker Simulation. 
-Currently, we support robomaker_simulation_msgs. See [README](https://github.com/aws-robotics/aws-robomaker-simulation-ros-pkgs/blob/master/robomaker_simulation_msgs/README.md)
+Currently, we support robomaker_simulation_msgs. See [README](robomaker_simulation_msgs/README.md)
 
 ## Documentation and Tutorials
 [AWS RoboMaker Documentation](https://docs.aws.amazon.com/robomaker)
@@ -12,4 +12,4 @@ This library is licensed under the Apache 2.0 License.
 
 ## Develop and Contribute
 
-See [Contribute](https://github.com/aws-robotics/aws-robomaker-simulation-ros-pkgs/blob/master/CONTRIBUTING.md) page.
+See [Contribute](CONTRIBUTING.md) page.


### PR DESCRIPTION
*Description of changes:*

These links should be relative and not point to master branch

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
