### PR TITLE
Remove rospy from CMakeLists.txt

### DIFF
--- a/robomaker_simulation_msgs/CMakeLists.txt
+++ b/robomaker_simulation_msgs/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 2.8.3)
 project(robomaker_simulation_msgs)
 
 find_package(catkin REQUIRED COMPONENTS
-    rospy
     std_msgs
     message_generation
 )


### PR DESCRIPTION
*Description of changes:*

This removes rospy from the CMakeLists.txt since it is not required. 

It is causing the bloom release to fail: https://travis-ci.org/AAlon/ROS1Prerelease/builds/608931656


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
